### PR TITLE
Remove sig term sig int

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -587,7 +587,7 @@ namespace crow
 
         std::unique_ptr<server_t> server_;
 
-        std::vector<int> signals_{SIGINT, SIGTERM};
+        std::vector<int> signals_{};
 
         bool server_started_{false};
         std::condition_variable cv_started_;

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -144,7 +144,7 @@ namespace crow
 
             signals_.async_wait(
               [&](const asio::error_code& /*error*/, int /*signal_number*/) {
-                  stop();
+                  // stop();
               });
 
             while (worker_thread_count != init_count)
@@ -187,12 +187,12 @@ namespace crow
 
         void signal_clear()
         {
-            signals_.clear();
+            //signals_.clear();
         }
 
         void signal_add(int signal_number)
         {
-            signals_.add(signal_number);
+            //signals_.add(signal_number);
         }
 
     private:


### PR DESCRIPTION
Removes signal registry for sigTerm and sigInt and some associated handling.  Server shutdown will be handled by parent program termination. 